### PR TITLE
Assemble BT messages from the commands, collect preset configuration

### DIFF
--- a/src.midi/README.md
+++ b/src.midi/README.md
@@ -31,6 +31,7 @@ Make sure that no other Bluetooth device is connected to your Spark, and start t
 You should see messages about MIDI device discovered.
 
 Push the leftmost button on the to row to connect / disconnect the pedal from amplifier.
+When pedal is not connected you can use your mobile app to change settings.
 
 The bottom row of the footswitch is changing amp presets when connected.
 

--- a/src.midi/README.md
+++ b/src.midi/README.md
@@ -12,7 +12,9 @@ You will need:
  - a Raspberry Pi 4 (2Gb version should work, 4Gb version was used). It gets hot, invest a few $$s for good passive cooling enclosure. You will need a power supply as well, the official one may be the safest way
  - Ubuntu 20.04 LTS from https://ubuntu.com/download/raspberry-pi installed on a SD card
 
-Unfortunately, my Pi doesn't boot with the MIDI controller attached, making it not possible to autostart the script in its current form. You will need a display and keyboard or set up SSH connction until the issue is resolved.
+If attached to USB3 (green) ports, Pi 3 boots with MIDI controller attached. An example service definition is in the repo, you may want to adjust paths in it
+before installing / enabling it.
+
 
 Following packages should be installed:
 
@@ -26,7 +28,9 @@ Make sure that no other Bluetooth device is connected to your Spark, and start t
 
     python3 ./midibox.py
 
-You should see messages about MIDI devices and Spark discovered (the Spark discovery may take some seconds)
+You should see messages about MIDI device discovered.
 
-The top row of the footswitch is changing amp presets.
+Push the leftmost button on the to row to connect / disconnect the pedal from amplifier.
+
+The bottom row of the footswitch is changing amp presets when connected.
 

--- a/src.midi/midibox.py
+++ b/src.midi/midibox.py
@@ -10,27 +10,25 @@ VERSION = '0.3-midi'
 SERVER_PORT = 2
 
 # Hex Code Spark Tone Commands
-TONE_1   = '01 38 00 00 00'
+TONE_1   = '01 38 00 00 00' # SET PRESET INT 0x## 0x##
 TONE_2   = '01 38 00 00 01'
 TONE_3   = '01 38 00 00 02'
 TONE_4   = '01 38 00 00 03'
 TONE_CMD_LIST = [TONE_1, TONE_2, TONE_3, TONE_4]
 
-CONFIG_1 = '02 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00'
-CONFIG_2 = '02 01 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00'
-CONFIG_3 = '02 01 00 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00'
-CONFIG_4 = '02 01 00 00 03 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00'
+CONFIG_1 = '02 01 00 00 00' # GET CONFIG INT 0x## 0x##
+CONFIG_2 = '02 01 00 00 01'
+CONFIG_3 = '02 01 00 00 02'
+CONFIG_4 = '02 01 00 00 03'
 CONFIG_CMD_LIST = [CONFIG_1, CONFIG_2, CONFIG_3, CONFIG_4]
 
-HW_NAME  = '02 11'
-HW_ID    = '02 23'
+HW_NAME  = '02 11' # GET NAME
+HW_ID    = '02 23' # GET ID
 
 class BluetoothInterface(object):
     def __init__(self):
         self.spark_mac = None
         self.bt_socket = None
-        self.scan()
-        self.connect()
 
     def scan(self, duration=10):
         devices = bluetooth.discover_devices(duration, lookup_names=True)
@@ -38,6 +36,14 @@ class BluetoothInterface(object):
             if str(name).startswith('Spark'):
                 logging.debug('Found {0} MAC {1}'.format(name, addr))
                 self.spark_mac = addr
+                return True
+        return False
+
+    def disconnect(self):
+        try:
+            self.bt_socket.close()
+        except bluetooth.btcommon.BluetoothError:
+            pass
 
     def connect(self):
         self.bt_socket = bluetooth.BluetoothSocket(bluetooth.RFCOMM)
@@ -63,22 +69,16 @@ class BluetoothInterface(object):
         msg = bytes.fromhex(bt_command)
         self.bt_socket.send(msg)
 
-    def receive(self) -> str:
-        last_byte = 0
-        message = ''
-        while  last_byte != 0xf7:
+    def receive(self):
+        last_message = False
+        message = []
+        while not last_message:
             data = self.bt_socket.recv(1024)
             if not data:
                 return message
-            last_byte = list(data)[-1]
-            # first 0x10 bytes are from known header, igonre them
-            if message == '':
-                # Also remove 'f0 01 xx xx' header from the message
-                logging.debug('Received {}'.format(bytes.hex(data)[0x14*2:]))
-                message += bytes.hex(data)[0x14*2:]
-            else:
-                logging.debug('Received {}'.format(bytes.hex(data)[0x10*2:]))
-                message += bytes.hex(data)[0x10*2:]
+            last_message = (list(data)[-1] == 0xf7) and (len(data) < 0x6a) 
+            logging.debug('Received {}'.format(bytes.hex(data)))
+            message.append(data)
         return message
 
 
@@ -142,43 +142,44 @@ class MidiInterface(object):
         DEBUG:root:[144, 49, 127]
         DEBUG:root:[144, 49, 0]
         """
-        slot = None
+        button = None
         msg = self.indev.get_message()
         if msg:
             message, deltatime = msg
             logging.debug('MIDI IN: %r' % (message))
             if message[0] == 144 and message[2] == 127:
-                slot = message[1] - 91
-                if (slot >=0) and (slot <=3):
-                    logging.debug('Changing to slot {0}'.format(slot))
-                    return slot
+                button = message[1] - 91
+                if (button >=0) and (button <=3):
+                    logging.debug('Button {0}'.format(button))
+                    return button
                 if message[1] == 86:
-                    slot = 4
+                    button = 4
                 if message[1] == 95:
-                    slot = 5
+                    button = 5
                 if message[1] == 48:
-                    slot = 6
+                    button = 6
                 if message[1] == 49:
-                    slot = 7
-                if slot is not None:
-                    logging.debug('Non-slot button {} pressed'.format(slot))
-                    return slot
-        return None
-        return None
-
-    def set_slot(self, slot: int):
-        logging.debug('Changed to slot {0}'.format(slot))
-        for button in range(0,4):
-            if button == slot:
-                msg = [ NOTE_ON, 91+button , 127 ]
-            else:
-                msg = [ NOTE_ON, 91+button , 0 ]
-            self.outdev.send_message(msg)
+                    button = 7
+                if button is not None:
+                    logging.debug('Button {}'.format(button))
+                    return button
         return None
 
 
-def tone_control_loop(midi: MidiInterface, bt: BluetoothInterface) -> None:
-    selected_slot = 0
+    def set_led(self, led: int, mode: bool):
+        notes = [91,92,93,94,86,95,48,49]
+        if led not in range(0,8):
+            return None
+        if mode:
+            velocity = 127
+        else:
+            velocity = 0
+        msg = [ NOTE_ON, notes[led], velocity]
+        self.outdev.send_message(msg)
+        return None
+
+
+def reconnect(bt):
     logging.debug('Amp ID')
     bt.send(HW_NAME)
     bt.receive()
@@ -190,20 +191,94 @@ def tone_control_loop(midi: MidiInterface, bt: BluetoothInterface) -> None:
         logging.debug('Preset {}'.format(slot))
         bt.send(CONFIG_CMD_LIST[slot])
         bt.receive()
+# 0-based, buttons are 0..7
+BUTTON_ONOFF = 0
+BUTTON_PRESET0 = 4 
+
+NUM_PRESETS = 4
+NUM_BUTTONS = 8
+
+def set_leds_midi_found(midi):
+    for led in range(0, NUM_BUTTONS):
+        midi.set_led(led, True)
+    time.sleep(0.5)
+    for led in range(0, NUM_BUTTONS):
+        midi.set_led(led, False)
+    time.sleep(0.5)
+    for led in range(0, NUM_BUTTONS):
+        midi.set_led(led, True)
+    time.sleep(0.5)
+    for led in range(0, NUM_BUTTONS):
+        midi.set_led(led, False)
+
+def set_leds_scan(midi):
+    for led in range(BUTTON_PRESET0,BUTTON_PRESET0+NUM_PRESETS):
+        midi.set_led(led, True)
+    midi.set_led(BUTTON_ONOFF, False)
+
+def set_leds_off(midi, spark_connected):
+    for led in range(BUTTON_PRESET0,BUTTON_PRESET0+NUM_PRESETS):
+        midi.set_led(led, False)
+    midi.set_led(BUTTON_ONOFF, spark_connected)
+
+def set_preset_led(midi, slot: int):
+    logging.debug('Changed to slot {0}'.format(slot))
+    for led in range(0, NUM_PRESETS):
+        midi.set_led(BUTTON_PRESET0+led, (led == slot))
+    return None
+
+def tone_control_loop(midi: MidiInterface) -> None:
+    set_leds_midi_found(midi)
+    selected_slot = 0
+    bt = BluetoothInterface()
+    spark_connected = False
+    set_leds_off(midi, spark_connected)
     while True:
-        selected_slot = midi.get_button()
-        if selected_slot is not None and selected_slot in range(0, 4):
-            bt.send(TONE_CMD_LIST[selected_slot])
-            midi.set_slot(selected_slot)
-            bt.receive()
+        button = midi.get_button()
+        if selected_slot is None:
+            time.sleep(0.1)
+            continue
+        if button == BUTTON_ONOFF:
+            if not spark_connected:
+                logging.debug('scan')
+                set_leds_scan(midi)
+                if bt.scan():
+                    logging.debug('connect')
+                    bt.connect()
+                    reconnect(bt)
+                    spark_connected = True
+            else:
+                logging.debug('disconnect')
+                bt.disconnect()
+                spark_connected = False
+            set_leds_off(midi, spark_connected)
+        if spark_connected and button in range(BUTTON_PRESET0, BUTTON_PRESET0+NUM_PRESETS):
+            selected_slot = button - BUTTON_PRESET0
+            try:
+                bt.send(TONE_CMD_LIST[selected_slot])
+                set_preset_led(midi, selected_slot)
+                bt.receive()
+            except bluetooth.btcommon.BluetoothError as e:
+                logging.info('BT connection lost')
+                bt.disconnect()
+                spark_connected = False
+                set_leds_off(midi, spark_connected)
         time.sleep(0.1)
 
 
 def midibox():
     logging.basicConfig(level=logging.DEBUG)
-    midi = MidiInterface()
-    bt = BluetoothInterface()
-    tone_control_loop(midi, bt)
+    midi = None
+    while midi is None:
+        try:
+            midi = MidiInterface()
+        except NoMidiDeviceException:
+            logging.debug('No MIDI, sleep 10 seconds')
+            time.sleep(10)
+    logging.debug('Draining MIDI queue....')
+    while midi.get_button() is not None:
+        pass # drain MIDI messages
+    tone_control_loop(midi)
 
 
 # Start 'main' logic

--- a/src.midi/midibox.py
+++ b/src.midi/midibox.py
@@ -59,7 +59,7 @@ class BluetoothInterface(object):
         suffix   = 'f7'.replace(' ','')
         command_len = len(prefix)/2 +                     1 + len(suffix1)/2 + len(suffix2)/2 + len(fake_seq)/2 + len(command)/2 + len(suffix)/2
         command_len = int(command_len)
-        bt_command =      prefix    + ('%0x' % command_len) +     suffix1    +     suffix2    +     fake_seq    +     command    +     suffix 
+        bt_command =      prefix    + ('%02x' % command_len) +     suffix1    +     suffix2    +     fake_seq    +     command    +     suffix 
         msg = bytes.fromhex(bt_command)
         self.bt_socket.send(msg)
 
@@ -70,9 +70,15 @@ class BluetoothInterface(object):
             data = self.bt_socket.recv(1024)
             if not data:
                 return message
-            logging.debug('Received {}'.format(bytes.hex(data)[0x10*2:]))
             last_byte = list(data)[-1]
-            message += bytes.hex(data)[0x10*2:]
+            # first 0x10 bytes are from known header, igonre them
+            if message == '':
+                # Also remove 'f0 01 xx xx' header from the message
+                logging.debug('Received {}'.format(bytes.hex(data)[0x14*2:]))
+                message += bytes.hex(data)[0x14*2:]
+            else:
+                logging.debug('Received {}'.format(bytes.hex(data)[0x10*2:]))
+                message += bytes.hex(data)[0x10*2:]
         return message
 
 

--- a/src.midi/midibox.service
+++ b/src.midi/midibox.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=MIDI pedal
+After=network.target bluetooth.service hciuart.service
+Wants=network-online.target bluetooth.target
+
+[Service]
+Restart=always
+Type=simple
+ExecStart=/home/ubuntu/dev/tinderboxpedal/src.midi/midibox.sh
+Environment=
+
+[Install]
+WantedBy=multi-user.target

--- a/src.midi/midibox.sh
+++ b/src.midi/midibox.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/bin/python3  /home/ubuntu/dev/tinderboxpedal/src.midi/midibox.py


### PR DESCRIPTION
There is no reason to keep the complete BT message in sources, they can be built dynamically from the actual commands.

Document a few more commands in code:
 - get preset configuration from the amp
 - get hardware name and serial number

Read preset configuration on startup.
Prepare to use second row of buttons on the footswitch to enable/disable individual pedals (WIP - needs parser of the preset configuration to be completed).